### PR TITLE
[merge] 修复创建目录不符合预期的问题

### DIFF
--- a/back_end/application/panel/controller/Problem.php
+++ b/back_end/application/panel/controller/Problem.php
@@ -220,7 +220,7 @@ class problem extends Base
         }
         $i = 0;
         foreach ($data as $item){
-            $data_path = $problem_path.'/'.(string)$i . config('wutoj_config.environment');
+            $data_path = $problem_path.'/'.(string)$i;
             if (!file_exists($data_path)) {
                 if(!mkdir($data_path, 0755, true) || !is_dir($data_path)){
                     return apiReturn(CODE_ERROR, '创建目录失败', '');


### PR DESCRIPTION
- 预期创建的data目录为 /path/to/data/${id}${environment} 的格式
- problem 格式保持不变